### PR TITLE
パッケージ名を単数形にした

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,7 +1,7 @@
 package main
 
-import "github.com/yatabis/Jehanne/TaskBoard/infrastructures"
+import "github.com/yatabis/Jehanne/TaskBoard/infrastructure"
 
 func main() {
-	infrastructures.New().Run()
+	infrastructure.New().Run()
 }

--- a/infrastructure/router.go
+++ b/infrastructure/router.go
@@ -1,4 +1,4 @@
-package infrastructures
+package infrastructure
 
 import (
 	"net/http"


### PR DESCRIPTION
Go の命名規則に従い、パッケージ名を単数形にしました。